### PR TITLE
add a UI folder to the mock-ats

### DIFF
--- a/server.js
+++ b/server.js
@@ -277,6 +277,29 @@ function webService(request, response) {
   });
 }
 
+function serveFile(requestPath, response) {
+  
+  console.log("Reading " + requestPath);
+  readFile(requestPath, function (err, data) {
+    var status, log;
+
+    if(err) status = 404, data = ERROR_RESPONSE, log = "Err:" + err;
+    else status = 200, log = "Success!";
+
+    response.writeHead(status, {
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Allow-Headers': 'X-Requested-With,Content-Type,Accept,Origin',
+      'Access-Control-Allow-Methods': 'GET,POST,HEAD',
+      'Access-Control-Max-Age': 1800,
+      'Transfer-Encoding': 'chunked'
+    });
+
+    response.write(data);
+    console.log("Requested for " + requestPath + " : " + log);
+    response.end();
+  });
+}
+
 http.createServer(function(request, response) {
   var pathname = url.parse(request.url, true).pathname;
 
@@ -287,6 +310,10 @@ http.createServer(function(request, response) {
 
     case /\/uploader/.test(pathname):
       uploader(request, response);
+      break;
+
+    case /\/ui/.test(pathname):
+      serveFile(path.join(process.cwd(), 'data/', pathname), response)
       break;
 
     default:


### PR DESCRIPTION
This allows us to unzip the tez ui.war into the mock-ats directory and use it.

Pending TODO items - automatically rewrite the ui/config.js with the mock-ats URL while sending it out.
