### PR TITLE
Adding TEZ_DAG_EXTRA_INFO and fix some issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   ],
   "author": "Sreenath Somarajapuram",
   "email": "somarajapuram@gmail.com",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/sreenaths/mock-ats.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sreenaths/mock-ats.git"
   },
   "license": "MIT",
   "dependencies": {
@@ -19,13 +19,12 @@
     "rsvp-that-works": "1.2.0",
     "line-by-line": "0.1.3",
     "request": "^2.49.0",
-    "mkdirp": "^0.5.0",
+    "mkdirp": "^0.5.1",
     "request-progress": "^0.3.1",
     "progress": "^1.1.8",
     "http-proxy": "^1.11.1",
     "formidable": "^1.0.14",
     "fs.extra": "^1.3.2",
-    "unzip2": "^0.2.5",
-    "mkdirp": "^0.5.1"
+    "unzip2": "^0.2.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ function getFilters(query) {
 
   return filters.reduce(function (obj, val) {
     var delimIndex = val.indexOf(":");
-    if(delimIndex > 0) obj[val.substr(0, delimIndex)] = val.substr(delimIndex + 1);
+    if(delimIndex > 0) obj[val.substr(0, delimIndex)] = JSON.parse(val.substr(delimIndex + 1));
     return obj;
   }, {});
 }
@@ -143,7 +143,7 @@ function dagUpload(request, response) {
 function extractData(dest, src) {
   if(src.application) dest.applications.push(src.application);
   if(src.dag) dest.dags.push(src.dag);
-
+  if(src['dag-extra-info']) dest.dag_extra_infos.push(src['dag-extra-info']);
   if(src.vertices) dest.vertices = dest.vertices.concat(src.vertices);
   if(src.tasks) dest.tasks = dest.tasks.concat(src.tasks);
   if(src.task_attempts) dest.task_attempts = dest.task_attempts.concat(src.task_attempts);
@@ -153,6 +153,7 @@ function extractFiles(zipFiles, callback) {
   var data = {
     applications: [],
     dags: [],
+    dag_extra_infos: [],
     vertices: [],
     tasks: [],
     task_attempts: []
@@ -198,14 +199,16 @@ function appendJSONEntities(path, data) {
   json.entities = json.entities.concat(data);
 
   mkdirp(path, function (err) {
-    fs.writeFile(file, JSON.stringify(json), {flags: 'r+'});
+    fs.writeFile(file, JSON.stringify(json), {flags: 'r+'}, function(err) {
+      if (err) throw err;
+    });
   });
 }
 
 function saveData(data) {
   appendJSONEntities('data/ws/v1/timeline/TEZ_DAG_ID', data.dags);
   appendJSONEntities('data/ws/v1/timeline/TEZ_APPLICATION', data.applications);
-
+  appendJSONEntities('data/ws/v1/timeline/TEZ_DAG_EXTRA_INFO', data.dag_extra_infos);
   appendJSONEntities('data/ws/v1/timeline/TEZ_VERTEX_ID', data.vertices);
   appendJSONEntities('data/ws/v1/timeline/TEZ_TASK_ID', data.tasks);
   appendJSONEntities('data/ws/v1/timeline/TEZ_TASK_ATTEMPT_ID', data.task_attempts);
@@ -264,7 +267,7 @@ function webService(request, response) {
       'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Headers': 'X-Requested-With,Content-Type,Accept,Origin',
       'Access-Control-Allow-Methods': 'GET,POST,HEAD',
-      'Access-Control-Allow-Origin': request.headers.origin,
+      'Access-Control-Allow-Origin': request.headers.origin || "*",
       'Access-Control-Max-Age': 1800,
       'Cache-Control': 'no-cache',
       'Pragma': 'no-cache',


### PR DESCRIPTION
Here are the exact steps I followed to get this to work. Posting so other can follow if need be

Development

Viewing the downloaded DAG timeline data locally.

The mock-ats development tool has been generated that allows uploading the DAG timeline data to a mock timeline server.

 

# build and run a stand alone timeline server

# pre-requisite node installed 

brew install node@12
export PATH="/usr/local/opt/node@12/bin:$PATH"
# get mock-ats an external tool

git clone https://github.com/sreenaths/mock-ats

cd mock-ats

# uploader uploads into mock-ats/data in a certain format. You may need to clear mock-ats/data manually

# install on the node webserver dependencies

npm install

# launch node server on port 8188

node server.js http://localhost 8188

# node server is running both an uploader and timeline server at port 8188

# navigate to http://127.0.0.1:8188/dagupload

# upload the dag timeline zip file

# keep the server running during UI testing below

 

# build and run the tez UI

mvn clean install -DskipTests -Dmaven.javadoc.skip -pl tez-ui -am

cd tez-ui/target/tez-ui-*-SNAPSHOT/

# launch the Tez UI on port 8000

simple-cors-http-server.py

``` simple-cors-http-server.py
#!/usr/bin/env python
from SimpleHTTPServer import SimpleHTTPRequestHandler
import BaseHTTPServer

class CORSRequestHandler (SimpleHTTPRequestHandler):
    def end_headers (self):
        self.send_header('Access-Control-Allow-Origin', '*')
        self.send_header('X-Content-Type-Options', 'nosniff')
        self.send_header('X-Frame-Options', 'SAMEORIGIN')
        self.send_header('X-XSS-Protection', '1; mode=block')
        SimpleHTTPRequestHandler.end_headers(self)

if __name__ == '__main__':
    BaseHTTPServer.test(CORSRequestHandler, BaseHTTPServer.HTTPServer)
```

# navigate to

http://127.0.0.1:8000/

# the dag now can be debugged locally