### PR TITLE
migrate to node-stream-zip as node-unzip-2 is not compatible with node 14 or 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,12 @@
     "rsvp-that-works": "1.2.0",
     "line-by-line": "0.1.3",
     "request": "^2.49.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^0.5.5",
     "request-progress": "^0.3.1",
     "progress": "^1.1.8",
     "http-proxy": "^1.11.1",
     "formidable": "^1.0.14",
     "fs.extra": "^1.3.2",
-    "node-unzip-2": "^0.2.8",
-    "mkdirp": "^0.5.5"
+    "node-stream-zip": "^1.14.0"
   }
 }


### PR DESCRIPTION
The node-unzip-2 fails under node js 14 and 16 as events are fired twice.

https://stackoverflow.com/questions/63524117/fs-createreadstream-with-pipe-fires-close-event-twice